### PR TITLE
auto_assignがPRだけでなくissueを作成したときにも動作してしまう問題を解決

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pghub-base (1.1.0)
+    pghub-base (1.1.1)
       faraday
       rails
 
@@ -70,7 +70,7 @@ GEM
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     rack (2.0.3)
-    rack-test (0.7.0)
+    rack-test (0.8.2)
       rack (>= 1.0, < 3)
     rails (5.1.4)
       actioncable (= 5.1.4)

--- a/app/controllers/pghub/base/webhooks_controller.rb
+++ b/app/controllers/pghub/base/webhooks_controller.rb
@@ -23,7 +23,9 @@ module Pghub::Base
       end
 
       if defined? Pghub::AutoAssign
-        Pghub::AutoAssign.post(issue_path, opened_pr_user) if action == 'opened'
+        if params[:webhook][:pull_request].present? && action == 'opened'
+          Pghub::AutoAssign.post(issue_path, opened_pr_user)
+        end
       end
 
       head 200

--- a/lib/pghub/base/version.rb
+++ b/lib/pghub/base/version.rb
@@ -1,5 +1,5 @@
 module Pghub
   module Base
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end


### PR DESCRIPTION
# WHAT
- @WatanabeDaisuke さんに教えていただいたバグを修正。
- PRだけでなくissueを作成したときにも動作してしまう問題が発生していた
- バージョンを1.1.1に変更

こちらのリリースが終わり次第、auto_assignの依存も変更してリリースします
→　https://github.com/playground-live/pghub-auto_assign/pull/4