### PR TITLE
gemをvendor/bundleディレクトリに保存するため.gitignoreに記述を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/dummy/db/*.sqlite3
 test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
+vendor/bundle


### PR DESCRIPTION
# WHAT
- .gitignoreにvendor/bundleを追加

# WHY
- ローカルの別プロジェクトでgemのバージョンを上げると、rake buildするたびにバージョンが上がってしまう問題を解決するため